### PR TITLE
chore: update member icon upload rules oc: 5142

### DIFF
--- a/app/Nova/Member.php
+++ b/app/Nova/Member.php
@@ -111,7 +111,9 @@ class Member extends Resource
                         ->storeAs(function () {
                             return 'icon.png';
                         })
-                        ->hideFromIndex(),
+                        ->hideFromIndex()
+                        ->rules('mimes:png')
+                        ->help('Upload a PNG file for the member icon.'),
                     Text::make(__('Contact Name'), 'contact_name')
                         ->rules('max:255')
                         ->hideFromIndex(),


### PR DESCRIPTION
Added validation to ensure only PNG files can be uploaded for the member icon. Included a help message to guide users on the file format required.